### PR TITLE
feat: use conversations.open instead of deprecated im.open

### DIFF
--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -22,7 +22,7 @@ module Lita
         end
 
         def im_open(user_id)
-          response_data = call_api("im.open", user: user_id)
+          response_data = call_api("conversations.open", users: user_id)
 
           SlackIM.new(response_data["channel"]["id"], user_id)
         end


### PR DESCRIPTION
`im.open` was deprecated, and would throw exceptions to that effect (although only sometimes, annoyingly). This PR ceases use of [`im.open`](https://api.slack.com/events/im_open) in favor of [`conversations.open`](https://api.slack.com/methods/conversations.open).