### PR TITLE
Make edit/delete consistent with add

### DIFF
--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -124,17 +124,22 @@ module Lita
           data["channel"]
         end
 
-        def dispatch_me_message(user)
+        def create_message(user, previous_message=nil)
           room = Lita::Room.find_by_id(channel)
           extensions = { timestamp: data["ts"], attachments: data["attachments"] }
           extensions[:thread_ts] = data["thread_ts"] if data["thread_ts"]
+          extensions[:previous_message] = data["previous_message"] if data["previous_message"]
           source = SlackSource.new(user: user, room: room || channel, extensions: extensions)
           source.private_message! if channel && channel[0] == "D"
           message = Message.new(robot, body, source)
           message.command! if source.private_message?
           message.extensions[:slack] = extensions
+          return message
+        end
+
+        def dispatch_me_message(user, previous_message=nil)
           log.debug("Dispatching message to Lita from #{user.id}.")
-          robot.receive(message)
+          robot.receive(create_message(user, previous_message))
         end
 
         def from_self?(user)
@@ -165,19 +170,31 @@ module Lita
 
         def handle_message
           return unless supported_subtype?
-          return if data["user"] == 'USLACKBOT'
-
-          user = User.find_by_id(data["user"]) || User.create(data["user"])
-
-          return if from_self?(user)
+          return if data["user"] == 'USLACKBOT'        
 
           case data["subtype"]
           when "message_deleted"
-            robot.trigger(:message_deleted, data)
+            user_from_data = data['previous_message']['user']
+            user = User.find_by_id(user_from_data) || User.create(user_from_data)
+            return if from_self?(user)
+            
+            message = create_message(user, previous_message=data['previous_message'])
+            response = Response.new(message, nil) #use nil as the pattern bots need to make their own assessment
+            robot.trigger(:message_deleted, response)
           when "message_changed"
-            robot.trigger(:message_changed, data)
+            user_from_data = data['previous_message']['user']
+            user = User.find_by_id(user_from_data) || User.create(user_from_data)
+            return if from_self?(user)
+
+            message = create_message(user, previous_message=data['previous_message'])
+            response = Response.new(message, nil) #use nil as the pattern bots need to make their own assessment
+            robot.trigger(:message_changed, response)
           else
-            puts('dispatch')
+            user_from_data = data['user']
+            user = User.find_by_id(user_from_data) || User.create(user_from_data)
+            return if from_self?(user)
+
+            puts("user for new: #{user.id} #{user.name} #{user.mention_name}")
             dispatch_me_message(user)
           end
         end

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -194,7 +194,6 @@ module Lita
             user = User.find_by_id(user_from_data) || User.create(user_from_data)
             return if from_self?(user)
 
-            puts("user for new: #{user.id} #{user.name} #{user.mention_name}")
             dispatch_me_message(user)
           end
         end


### PR DESCRIPTION
This makes the edit and delete of message consistent with add so that handlers can handle the body the same way