### PR TITLE
#180 - Update Slack connection

### DIFF
--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -151,8 +151,7 @@ module Lita
             SlackIM.from_data_array(response_data["ims"]),
             SlackUser.from_data(response_data["self"]),
             SlackUser.from_data_array(response_data["users"]),
-            SlackChannel.from_data_array(response_data["channels"]) +
-              SlackChannel.from_data_array(response_data["groups"]),
+            SlackChannel.from_data_array(response_data["groups"]),
             response_data["url"],
           )
           Lita.logger.debug("Finished building TeamData")

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -143,9 +143,9 @@ module Lita
           call_api("channels.setTopic", channel: channel, topic: topic)
         end
 
-        def rtm_start
-          Lita.logger.debug("Starting `rtm_start` method")
-          response_data = call_api("rtm.start")
+        def rtm_connect
+          Lita.logger.debug("Starting `rtm_connect` method")
+          response_data = call_api("rtm.connect")
           Lita.logger.debug("Started building TeamData")
           team_data = TeamData.new(
             SlackIM.from_data_array(response_data["ims"]),
@@ -156,7 +156,7 @@ module Lita
             response_data["url"],
           )
           Lita.logger.debug("Finished building TeamData")
-          Lita.logger.debug("Finishing method `rtm_start`")
+          Lita.logger.debug("Finishing method `rtm_connect`")
           team_data
         end
 
@@ -167,14 +167,14 @@ module Lita
         attr_reader :post_message_config
 
         def call_api(method, post_data = {})
-          Lita.logger.debug("Starting request to Slack API with rtm.start")
+          Lita.logger.debug("Starting request to Slack API with rtm.connect")
           response = connection.post(
             "https://slack.com/api/#{method}",
             { token: config.token }.merge(post_data)
           )
-          Lita.logger.debug("Finished request to Slack API rtm.start")
+          Lita.logger.debug("Finished request to Slack API rtm.connect")
           data = parse_response(response, method)
-          Lita.logger.debug("Finished parsing rtm.start response")
+          Lita.logger.debug("Finished parsing rtm.connect response")
           raise "Slack API call to #{method} returned an error: #{data["error"]}." if data["error"]
 
           data

--- a/lib/lita/adapters/slack/im_mapping.rb
+++ b/lib/lita/adapters/slack/im_mapping.rb
@@ -15,7 +15,9 @@ module Lita
         end
 
         def add_mappings(ims)
-          ims.each { |im| add_mapping(im) }
+          unless ims.nil?
+            ims.each { |im| add_mapping(im) }
+          end
         end
 
         def im_for(user_id)

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -17,7 +17,7 @@ module Lita
 
         class << self
           def build(robot, config)
-            team_data = API.new(config).rtm_start
+            team_data = API.new(config).rtm_connect
             new(robot, config, team_data)
           end
         end
@@ -64,7 +64,7 @@ module Lita
             # Slack periodically closes the websocket connection
             if event.code.to_s == '1006'
               queue.delete(@websocket) if queue
-              @team_data = API.new(@config).rtm_start
+              @team_data = API.new(@config).rtm_connect
               @im_mapping = IMMapping.new(API.new(@config), @team_data.ims)
               @websocket_url = @team_data.websocket_url
               @robot_id = @team_data.self.id

--- a/lib/lita/adapters/slack/slack_channel.rb
+++ b/lib/lita/adapters/slack/slack_channel.rb
@@ -18,7 +18,9 @@ module Lita
 
           # @api private
           def from_data_array(channels_data)
+            unless channels_data.nil?
             channels_data.map { |channel_data| from_data(channel_data) }
+            end
           end
         end
 

--- a/lib/lita/adapters/slack/slack_im.rb
+++ b/lib/lita/adapters/slack/slack_im.rb
@@ -5,7 +5,9 @@ module Lita
       class SlackIM
         class << self
           def from_data_array(ims_data)
-            ims_data.map { |im_data| from_data(im_data) }
+            unless ims_data.nil?
+              ims_data.map { |im_data| from_data(im_data) }
+            end
           end
 
           def from_data(im_data)

--- a/lib/lita/adapters/slack/slack_user.rb
+++ b/lib/lita/adapters/slack/slack_user.rb
@@ -17,7 +17,9 @@ module Lita
 
           # @api private
           def from_data_array(users_data)
-            users_data.map { |user_data| from_data(user_data) }
+            unless users_data.nil?
+              users_data.map { |user_data| from_data(user_data) }
+            end
           end
         end
 

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -794,11 +794,11 @@ describe Lita::Adapters::Slack::API do
     end
   end
 
-  describe "#rtm_start" do
+  describe "#rtm_connect" do
     let(:http_status) { 200 }
     let(:stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.post('https://slack.com/api/rtm.start', token: token) do
+        stub.post('https://slack.com/api/rtm.connect', token: token) do
           [http_status, {}, http_response]
         end
       end
@@ -818,25 +818,25 @@ describe Lita::Adapters::Slack::API do
       end
 
       it "has data on the bot user" do
-        response = subject.rtm_start
+        response = subject.rtm_connect
 
         expect(response.self.id).to eq('U12345678')
       end
 
       it "has an array of IMs" do
-        response = subject.rtm_start
+        response = subject.rtm_connect
 
         expect(response.ims[0].id).to eq('D024BFF1M')
       end
 
       it "has an array of users" do
-        response = subject.rtm_start
+        response = subject.rtm_connect
 
         expect(response.users[0].id).to eq('U023BECGF')
       end
 
       it "has a WebSocket URL" do
-        response = subject.rtm_start
+        response = subject.rtm_connect
 
         expect(response.websocket_url).to eq('wss://example.com/')
       end

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -20,7 +20,7 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
 
   let(:rtm_connect_response) do
     Lita::Adapters::Slack::TeamData.new(
-      [],
+      nil,
       Lita::Adapters::Slack::SlackUser.new('U12345678', 'carl', nil, raw_user_data),
       [Lita::Adapters::Slack::SlackUser.new('U12345678', 'carl', '', raw_user_data)],
       [channel],

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -9,7 +9,7 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
     thread.join
   end
 
-  subject { described_class.new(robot, config, rtm_start_response) }
+  subject { described_class.new(robot, config, rtm_connect_response) }
 
   let(:api) { instance_double("Lita::Adapters::Slack::API") }
   let(:registry) { Lita::Registry.new }
@@ -18,7 +18,7 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
   let(:channel) { Lita::Adapters::Slack::SlackChannel.new('C2147483705', 'general', 1360782804, 'U023BECGF', metadata) }
   let(:metadata) { Hash.new }
 
-  let(:rtm_start_response) do
+  let(:rtm_connect_response) do
     Lita::Adapters::Slack::TeamData.new(
       [],
       Lita::Adapters::Slack::SlackUser.new('U12345678', 'carl', nil, raw_user_data),
@@ -39,14 +39,14 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
   describe ".build" do
     before do
       allow(Lita::Adapters::Slack::API).to receive(:new).with(config).and_return(api)
-      allow(api).to receive(:rtm_start).and_return(rtm_start_response)
+      allow(api).to receive(:rtm_connect).and_return(rtm_connect_response)
     end
 
-    it "constructs a new RTMConnection with the results of rtm.start data" do
+    it "constructs a new RTMConnection with the results of rtm.connect data" do
       expect(described_class.build(robot, config)).to be_an_instance_of(described_class)
     end
 
-    it "creates users with the results of rtm.start data" do
+    it "creates users with the results of rtm.connect data" do
       expect_any_instance_of(Lita::Adapters::Slack::RTMConnection).to receive(:fork).and_yield do
         expect(Lita.logger).to receive(:debug).with("Inserting 1 users")
         expect(Lita::Adapters::Slack::UserCreator).to receive(:create_users)
@@ -55,7 +55,7 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
       described_class.build(robot, config)
     end
 
-    it "creates rooms with the results of rtm.start data" do
+    it "creates rooms with the results of rtm.connect data" do
       expect_any_instance_of(Lita::Adapters::Slack::RTMConnection).to receive(:fork).and_yield do
         expect(Lita.logger).to receive(:debug).with("Inserting 1 channels")
         expect(Lita::Adapters::Slack::RoomCreator).to receive(:create_rooms)


### PR DESCRIPTION
Updates Slack connection logic to use `rtm.connect` instead of `rtm.start` as [`rtm.start` is retired](https://api.slack.com/changelog/2021-10-rtm-start-to-stop).

Also add various `nil` checks as the response data returned by `rtm.connect` is different than the data previously returned by `rtm.start`.